### PR TITLE
Add links to config on Getting Started

### DIFF
--- a/views/docs.jade
+++ b/views/docs.jade
@@ -23,7 +23,8 @@ block content
 
       p There are a number of ways to configure CSScomb:
       ul
-        li Use one of predefined configs
+        li Use one of the <a href='https://github.com/csscomb/csscomb.js/tree/dev/config'>predefined configs</a>.
+        li <a href='/config'>Build a custom config file</a>
         li Put <code>.csscomb.json</code> file in the project root.
         li Set path to config's file
         li Use <code>.css</code> file as a template


### PR DESCRIPTION
Current | Proposed
:--:|:--:
![csscomb getting started](https://user-images.githubusercontent.com/6686963/46173217-459ce700-c26b-11e8-800c-5388d3f549f4.png) | ![csscomb getting started 1](https://user-images.githubusercontent.com/6686963/46173225-4897d780-c26b-11e8-9174-e0bb445bc184.png)

Right now the Getting Started page is unclear on how and where to get a config file. I've added two links: one to the predefined config files, and one to the build-your-own config page.